### PR TITLE
Update JAXB dependencies for JDK 11.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,15 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 scalaVersion := "2.12.2"
 
+val jaxbVersion = "2.3.0"
+
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
 libraryDependencies += "com.h2database" % "h2" % "1.4.196"
+
+libraryDependencies += "javax.xml.bind" % "jaxb-api" % jaxbVersion
+libraryDependencies += "com.sun.xml.bind" % "jaxb-core" % jaxbVersion
+libraryDependencies += "com.sun.xml.bind" % "jaxb-impl" % jaxbVersion
+
+libraryDependencies += "javax.activation" % "activation" % "1.1.1"
+


### PR DESCRIPTION
I'm not sure if this is something you want, but when I was playing around with your tutorial, I faced some issues with JAXB because of the way Oracle has been packaging dependencies. A quick google resolved this for me. If this is useful to you, I thought I'd share.