### PR TITLE
Lowercase task keys

### DIFF
--- a/ui-build.sbt
+++ b/ui-build.sbt
@@ -42,14 +42,14 @@ def executeProdBuild(implicit dir: File): Int = ifNodeModulesInstalled(runOnComm
 
 // Create frontend build tasks for prod, dev and test execution.
 
-lazy val `ui-test` = taskKey[Unit]("Run UI tests when testing application.")
+lazy val `ui-test` = taskKey[Unit]("run UI tests when testing application.")
 
 `ui-test` := {
   implicit val userInterfaceRoot = baseDirectory.value / "ui"
   if (executeUiTests != Success) throw new Exception("UI tests failed!")
 }
 
-lazy val `ui-prod-build` = taskKey[Unit]("Run UI build when packaging the application.")
+lazy val `ui-prod-build` = taskKey[Unit]("run UI build when packaging the application.")
 
 `ui-prod-build` := {
   implicit val userInterfaceRoot = baseDirectory.value / "ui"


### PR DESCRIPTION
When running with sbt 1.2.8 and scala 2.12.8 I got the error:

```
error] java.lang.IllegalArgumentException: requirement failed: A named attribute key must start with a lowercase letter: Run UI tests when testing application.
[error] 	at scala.Predef$.require(Predef.scala:277)
[error] 	at sbt.internal.util.AttributeKey$$anon$1.<init>(Attributes.scala:109)
[error] 	at sbt.internal.util.AttributeKey$.make(Attributes.scala:105)
[error] 	at sbt.internal.util.AttributeKey$.apply(Attributes.scala:94)
[error] 	at sbt.internal.util.AttributeKey$.apply(Attributes.scala:79)
[error] 	at sbt.TaskKey$.apply(Structure.scala:686)
[error] 	at $80297333e4bd37da6373$.ui$minustest$lzycompute(ui-build.sbt:45)
```

It would appear these keys should now be lower cased (after a cursory check)