### PR TITLE
Adds Dockerization instructions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,61 @@ GET        /*file        controllers.FrontendController.assetOrDefault(file)
 * Make output directory ROOT/public/
 * Implement a proxy to localhost:9000
 
+## Dockerizing your application.
+
+Play's plugin already includes the [SBT Native Packager](https://www.scala-sbt.org/sbt-native-packager/) in your project, so containerizing your application is pretty straightforward.
+
+### ui-build.sbt
+
+`ui-build.sbt` needs to be told that we want to build our production code when we publish a docker container. Add the following line to `ui-build.sbt`.
+```sbt
+publishLocal in Docker := ((publishLocal in Docker) dependsOn `ui-prod-build`).value
+```
+
+### Configuration
+
+In order to run a docker container, a few configuration changes need to be made. First, add
+```conf
+play.server.pidfile.path=/dev/null
+```
+to your conf/application.conf file. Each docker container is a single process, so we don't need play to monitor a pidfile.
+Next, because the docker container will be running a production version of the build, we need to tell it to get a valid application secret from the container's environment.
+
+`conf/application.conf` already has a `play.http.secret.key` entry. Add the following line _after_ the already-present line.
+```conf
+play.http.secret.key=${?APPLICATION_SECRET}
+```
+
+### Logging
+
+Logging in a docker container is generally done to STDOUT, and then fetched with the `docker logs` command. The default logging set up in this project is to include writing out to a file at /opt/docker/logs/application.log.
+
+To solve this, we'll get rid of the file appender in `conf/logback.xml`. Remove the following lines:
+
+```xml
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder>
+      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+  ...
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+```
+
+### Creating and Running your container
+
+To build the new docker container, run:
+```
+sbt docker:publishLocal
+```
+And to run it, use:
+```
+docker run -i -t -p 9000:9000 -e APPLICATION_SECRET=$MY_APP_SECRET <project-name>:<project-version>
+```
+
 ## Looking for some other frontend framework or language choice
 
 * [Java Play React Seed](https://github.com/yohangz/java-play-react-seed)


### PR DESCRIPTION
Adds README instructions for dockerizing the play-react app. 

I contained the information all within the Readme, since the modifications are generally only something you want if you're going to be running your app in a container. Not sure if you'd prefer another method of adding these instructions. I just went through this process so I thought I'd capture it by adding it somewhere. The section added to the README is relatively substantial, so if there's a more appropriate way to share this information, let me know (scala-play-react-docker-seed?)